### PR TITLE
Adding liveness & readiness probe server endpoint for TalariaDB startup server

### DIFF
--- a/deploy/application.yaml
+++ b/deploy/application.yaml
@@ -50,6 +50,24 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              httpHeaders:
+                - name: x-talaria-readiness
+                  value: healthz
+              port: 8082
+            initialDelaySeconds: 3
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              httpHeaders:
+                - name: x-envoy-livenessprobe
+                  value: healthz
+              port: 8082
+            initialDelaySeconds: 10
           resources:
             requests:
               memory: "1000Mi"

--- a/deploy/application.yaml
+++ b/deploy/application.yaml
@@ -39,6 +39,9 @@ spec:
               protocol: TCP
             - containerPort: 7946
               protocol: UDP
+            - name: liveness-port
+              containerPort: 8082
+              hostPort: 8082
           imagePullPolicy: Always
           env:
             - name: TALARIA_CONF_URI
@@ -57,7 +60,7 @@ spec:
               httpHeaders:
                 - name: x-talaria-readiness
                   value: healthz
-              port: 8082
+              port: liveness-port
             initialDelaySeconds: 3
           livenessProbe:
             httpGet:
@@ -66,7 +69,7 @@ spec:
               httpHeaders:
                 - name: x-envoy-livenessprobe
                   value: healthz
-              port: 8082
+              port: liveness-port
             initialDelaySeconds: 10
           resources:
             requests:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1
 	github.com/gopherjs/gopherjs v0.0.0-20200209183636-89e6cbcd0b6d // indirect
+	github.com/gorilla/mux v1.7.4
 	github.com/grab/async v0.0.5
 	github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4
 	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200209183636-89e6cbcd0b6d h1:vr95xIx8Eg3vCzZPxY3rCwTfkjqNDt/FgVqTOk0WByk=
 github.com/gopherjs/gopherjs v0.0.0-20200209183636-89e6cbcd0b6d/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grab/async v0.0.5 h1:QESBFAKiq5ocTtIcRh8gdha5Xgvu0yStGUefZsOWLPc=
 github.com/grab/async v0.0.5/go.mod h1:8zY9m1tryEmU2px8GLmWrHt7QXSQOhyurytRQ3LrzjQ=
 github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4 h1:60gBOooTSmNtrqNaRvrDbi8VAne0REaek2agjnITKSw=
@@ -198,6 +200,8 @@ github.com/kelindar/loader v0.0.10 h1:af6iHps0yk20BnRnYAOu+hLarZubIgEaZUcbyHCWJE
 github.com/kelindar/loader v0.0.10/go.mod h1:zhlDtwZnZ2I0Pq5tYScI+VWvvhItHGGJT5tLsAY1RQs=
 github.com/kelindar/lua v0.0.5 h1:VqJQGl74ub7fiZcSygHV4aZw/IbFKXA6vzk4pEUu4mk=
 github.com/kelindar/lua v0.0.5/go.mod h1:zCY2muj80Y5c3odwn4Ql6kjzpk3GAq9V4JwuVGLOsdA=
+github.com/kelindar/lua v0.0.6 h1:UeM5wedaRI5IYvXBHi2yVu8Kc2IJH6tSB7tqT191FBU=
+github.com/kelindar/lua v0.0.6/go.mod h1:zCY2muj80Y5c3odwn4Ql6kjzpk3GAq9V4JwuVGLOsdA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 type K8s struct {
-	ProbePort int32 `json:"probePort" yaml:"probePort" env:"PROBEPORT"` // The port which is used for liveliness and readiness probes (default: 8080)
+	ProbePort int32 `json:"probePort" yaml:"probePort" env:"PROBEPORT"` // The port which is used for liveness and readiness probes (default: 8080)
 }
 
 // Tables is a list of table configs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	Tables   Tables     `json:"tables" yaml:"tables" env:"TABLES"`
 	Statsd   *StatsD    `json:"statsd,omitempty" yaml:"statsd" env:"STATSD"`
 	Computed []Computed `json:"computed" yaml:"computed" env:"COMPUTED"`
+	K8s      *K8s       `json:"k8s,omitempty" yaml:"k8s" env:"K8S"`
+}
+
+type K8s struct {
+	ProbePort int32 `json:"probePort" yaml:"probePort" env:"PROBEPORT"` // The port which is used for liveliness and readiness probes (default: 8080)
 }
 
 // Tables is a list of table configs

--- a/internal/config/sample_config.yaml
+++ b/internal/config/sample_config.yaml
@@ -27,3 +27,5 @@ tables:
 statsd:
   host: "statsd-host"
   port: 8126
+k8s: # Optional value to set in k8s env. when server need liveliness & readiness probes
+  probePort: 8082

--- a/internal/config/sample_config.yaml
+++ b/internal/config/sample_config.yaml
@@ -27,5 +27,5 @@ tables:
 statsd:
   host: "statsd-host"
   port: 8126
-k8s: # Optional value to set in k8s env. when server need liveliness & readiness probes
+k8s: # Optional value to set in k8s env. when server need liveness & readiness probes
   probePort: 8082

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	monitor.Info("server: joining cluster on %s...", conf.Domain)
 	gossip.JoinHostname(conf.Domain)
 
-	// run HTTP server for readiness and liveliness probes if k8s config is set
+	// run HTTP server for readiness and liveness probes if k8s config is set
 	if conf.K8s != nil {
 		startHTTPServerAsync(conf.K8s.ProbePort)
 	}

--- a/main.go
+++ b/main.go
@@ -5,10 +5,14 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/kelindar/lua"
 	"github.com/kelindar/talaria/internal/config"
@@ -96,6 +100,11 @@ func main() {
 	monitor.Info("server: joining cluster on %s...", conf.Domain)
 	gossip.JoinHostname(conf.Domain)
 
+	// run HTTP server for readiness and liveliness probes if k8s config is set
+	if conf.K8s != nil {
+		startHTTPServerAsync(conf.K8s.ProbePort)
+	}
+
 	// Start listen
 	monitor.Info("server: starting...")
 	monitor.Count1(logTag, "start")
@@ -111,6 +120,23 @@ func onSignal(callback func(sig os.Signal)) {
 	go func() {
 		for sig := range c {
 			callback(sig)
+		}
+	}()
+}
+
+func startHTTPServerAsync(portNum int32) {
+	go func() {
+		handler := mux.NewRouter()
+		handler.HandleFunc("/healthz", func(resp http.ResponseWriter, req *http.Request) {
+			_, _ = resp.Write([]byte(`talaria-health-check`))
+		}).Methods(http.MethodGet, http.MethodHead)
+
+		server := &http.Server{
+			Addr:    fmt.Sprintf(":%d", portNum),
+			Handler: handler,
+		}
+		if err := server.ListenAndServe(); err != nil {
+			panic(err)
 		}
 	}()
 }


### PR DESCRIPTION
- This MR aims at adding liveness and readiness ports which improves service resiliency & robustness. 
- Parameters of probes like initialDelaySeconds, periodSeconds and failureThreshold will be decided during testing.

References:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
https://blog.colinbreck.com/kubernetes-liveness-and-readiness-probes-how-to-avoid-shooting-yourself-in-the-foot/