### PR TITLE
Add a compact before close

### DIFF
--- a/internal/storage/compact/compact.go
+++ b/internal/storage/compact/compact.go
@@ -82,6 +82,17 @@ func (s *Storage) Delete(keys ...key.Key) error {
 
 // Compact runs the compaction on the storage
 func (s *Storage) Compact(ctx context.Context) (interface{}, error) {
+	return s.compactWithSync(ctx, false)
+}
+
+func (s *Storage) mergeTask(keys []key.Key, blocks []block.Block, schema typeof.Schema) async.Task {
+	return async.NewTask(func(ctx context.Context) (_ interface{}, err error) {
+		s.merge(keys, blocks, schema)
+		return
+	})
+}
+
+func (s *Storage) compactWithSync(ctx context.Context, sync bool) (interface{}, error) {
 	var hash uint32
 	var blocks []block.Block
 	var merged []key.Key
@@ -111,8 +122,12 @@ func (s *Storage) Compact(ctx context.Context) (interface{}, error) {
 			return false
 		}
 
-		// Merge asynchronously and delete the keys on a successful merge
-		queue <- s.merge(merged, blocks, schema)
+		if sync == true {
+			s.merge(merged, blocks, schema)
+		} else {
+			// Merge asynchronously and delete the keys on a successful merge
+			queue <- s.mergeTask(merged, blocks, schema)
+		}
 
 		// Reset both the schema and the set of blocks
 		blocks = make([]block.Block, 0, 16)
@@ -129,7 +144,12 @@ func (s *Storage) Compact(ctx context.Context) (interface{}, error) {
 
 	// Merge one last time if we still have block
 	if len(blocks) > 0 {
-		queue <- s.merge(merged, blocks, schema)
+		if sync == true {
+			s.merge(merged, blocks, schema)
+		} else {
+			// Merge asynchronously and delete the keys on a successful merge
+			queue <- s.mergeTask(merged, blocks, schema)
+		}
 	}
 
 	// Wait for the pool to be close
@@ -138,42 +158,42 @@ func (s *Storage) Compact(ctx context.Context) (interface{}, error) {
 }
 
 // merge adds an key-value pair to the underlying database
-func (s *Storage) merge(keys []key.Key, blocks []block.Block, schema typeof.Schema) async.Task {
-	return async.NewTask(func(ctx context.Context) (_ interface{}, err error) {
+func (s *Storage) merge(keys []key.Key, blocks []block.Block, schema typeof.Schema) {
 
-		if len(blocks) == 0 {
+	if len(blocks) == 0 {
+		return
+	}
+	// Get the max expiration time for merging
+	now, max := time.Now().Unix(), int64(0)
+	for _, b := range blocks {
+		if b.Expires > max {
+			max = b.Expires
+		}
+	}
+
+	// Merge all blocks together
+	if key, value := s.merger.Merge(blocks, schema); key != nil {
+		// Append to the destination
+		ttl := time.Duration(max-now) * time.Second
+		if err := s.dest.Append(key, value, ttl); err != nil {
+			s.monitor.Count1(ctxTag, "error", "type:append")
+			s.monitor.Error(err)
 			return
 		}
-		// Get the max expiration time for merging
-		now, max := time.Now().Unix(), int64(0)
-		for _, b := range blocks {
-			if b.Expires > max {
-				max = b.Expires
-			}
-		}
+	}
 
-		// Merge all blocks together
-		if key, value := s.merger.Merge(blocks, schema); key != nil {
-			// Append to the destination
-			ttl := time.Duration(max-now) * time.Second
-			if err = s.dest.Append(key, value, ttl); err != nil {
-				s.monitor.Count1(ctxTag, "error", "type:append")
-				s.monitor.Error(err)
-				return
-			}
-		}
+	//  Delete all of the keys that we have appended
+	if err := s.buffer.Delete(keys...); err != nil {
+		s.monitor.Count1(ctxTag, "error", "type:delete")
+		s.monitor.Error(err)
+	}
+	return
 
-		//  Delete all of the keys that we have appended
-		if err = s.buffer.Delete(keys...); err != nil {
-			s.monitor.Count1(ctxTag, "error", "type:delete")
-			s.monitor.Error(err)
-		}
-		return
-	})
 }
 
 // Close is used to gracefully close storage.
 func (s *Storage) Close() error {
 	s.compact.Cancel()
+	s.compactWithSync(context.Background(), true)
 	return storage.Close(s.buffer, s.dest)
 }


### PR DESCRIPTION
1. Add a final flush before close to drain all the data before the instance terminate