### PR TITLE
Support JSON string input if desired static schema column is JSON

### DIFF
--- a/internal/encoding/block/from_orc.go
+++ b/internal/encoding/block/from_orc.go
@@ -114,6 +114,8 @@ func convertToJSON(value interface{}) (string, bool) {
 			remap[fmt.Sprintf("%v", v.Key)] = v.Value
 		}
 		value = remap
+	case string:
+		return value.(string), true
 	case orctype.Struct:
 	case []interface{}:
 	case interface{}:


### PR DESCRIPTION
Resolves #38. This also reduces CPU requirement as upstream has perfomed the marshalling. Such workarounds can be reworked when presto thrift supports map in the future.

Compared in a separate script where we marshalled input json and wrote into orc and a map input in orc. Produced output is the same.
 