### PR TITLE
Fix typeof for nil values

### DIFF
--- a/internal/encoding/typeof/typeof.go
+++ b/internal/encoding/typeof/typeof.go
@@ -83,6 +83,10 @@ func FromOrc(desc *orc.TypeDescription) (Type, bool) {
 
 // FromType gets the type from a reflect.Type
 func FromType(rt reflect.Type) (Type, bool) {
+	if rt == nil {
+		return Unsupported, false
+	}
+
 	switch rt.Name() {
 	case "int32":
 		return Int32, true

--- a/internal/encoding/typeof/typeof_test.go
+++ b/internal/encoding/typeof/typeof_test.go
@@ -53,7 +53,11 @@ func TestFromType(t *testing.T) {
 		assert.Equal(t, Unsupported, typ)
 		assert.False(t, ok)
 	}
-
+	{
+		typ, ok := FromType(reflect.TypeOf(nil))
+		assert.Equal(t, Unsupported, typ)
+		assert.False(t, ok)
+	}
 }
 
 func TestReflect(t *testing.T) {


### PR DESCRIPTION
This fixes an issue where `FromType` panics if reflect is unable to figure out the type of the value.