### PR TITLE
Added load balancer option

### DIFF
--- a/client/golang/client_opts.go
+++ b/client/golang/client_opts.go
@@ -15,11 +15,12 @@ type Option func(client *Client)
 
 // netconf defines connection pool configuration for a gRPC service
 type netconf struct {
-	CircuitOptions map[string]hystrix.CommandConfig
-	Address        string
-	DialTimeout    time.Duration
-	Credentials    credentials.TransportCredentials
-	NonBlocking    bool // once set to true, the client will be returned before connection gets ready
+	CircuitOptions map[string]hystrix.CommandConfig // Circuit configuration
+	Address        string                           // Endpoint of the server
+	DialTimeout    time.Duration                    // Dial timaout
+	Credentials    credentials.TransportCredentials // Transport credentials to use
+	NonBlocking    bool                             // once set to true, the client will be returned before connection gets ready
+	LoadBalancer   string                           // gRPC load balancing strategy
 }
 
 // WithNetwork specifies the configuration for a connection.
@@ -52,8 +53,16 @@ func WithCredential(credentials credentials.TransportCredentials) Option {
 	}
 }
 
+// WithNonBlock creates a non-blocking gRPC dial()
 func WithNonBlock() Option {
 	return func(client *Client) {
 		client.netconf.NonBlocking = true
+	}
+}
+
+// WithLoadBalancer specifies the load balancer to use
+func WithLoadBalancer(name string) Option {
+	return func(client *Client) {
+		client.netconf.LoadBalancer = name
 	}
 }

--- a/client/golang/client_opts_test.go
+++ b/client/golang/client_opts_test.go
@@ -5,13 +5,17 @@ import (
 	"time"
 
 	"github.com/myteksi/hystrix-go/hystrix"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWithNetwork(t *testing.T) {
 	client, _ := Dial("invalid", WithNonBlock(), WithNetwork(10*time.Second))
 	assert.Equal(t, 10*time.Second, client.netconf.DialTimeout)
+}
+
+func TestWithLoadBalancer(t *testing.T) {
+	client, _ := Dial("invalid", WithNonBlock(), WithLoadBalancer("round_robin"))
+	assert.Equal(t, "round_robin", client.netconf.LoadBalancer)
 }
 
 func TestWithCircuit(t *testing.T) {


### PR DESCRIPTION
This PR adds a `WithLoadBalancer()` option to the Golang client of Talaria.