### PR TITLE
Fix substreaming to per table level

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If your organisation needs a reliable and scalable data ingestion platform, you 
 
 ![alt text](.github/images/ingest.png)
 
-In order to setup Talaria as an ingestion platform, you will need to enable `compaction` in the configuration, something along these lines:
+In order to setup Talaria as an ingestion platform, you will need specify a table, in this case "eventlog", and enable `compaction` in the configuration, something along these lines:
 
 ```yaml
 mode: staging
@@ -54,12 +54,14 @@ env: staging
 domain: "talaria-headless.default.svc.cluster.local"
 storage:
   dir: "/data"
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    s3:                                  # sink to Amazon S3
-      region: "ap-southeast-1"
-      bucket: "bucket"
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      s3:                                  # sink to Amazon S3
+        region: "ap-southeast-1"
+        bucket: "bucket"
 ...
 ```
 
@@ -79,6 +81,7 @@ Below is a list of currently supported sinks and their example configurations:
 - [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/) using [azure sink](./internal/storage/writer/azure).
 - [Minio](https://min.io/) using [s3 sink](./internal/storage/writer/s3), a custom endpoint and us-east-1 region.
 - [Google Big Query](https://cloud.google.com/bigquery/) using [bigquery sink](./internal/storage/writer/bigquery).
+- Talaria itself using [talaria sink](./internal/storage/writer/talaria).
 
 ## Hot Data Query with Talaria
 
@@ -107,9 +110,8 @@ readers:
 storage:
   dir: "/data"
 tables:
-  timeseries:
-    name: eventlog
-    ttl: 3600
+  eventlog:
+    ttl: 3600         # data is persisted for 1 hour
     hashBy: event
     sortBy: time
 ...

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,6 @@ type Config struct {
 	Statsd   *StatsD    `json:"statsd,omitempty" yaml:"statsd" env:"STATSD"`
 	Computed []Computed `json:"computed" yaml:"computed" env:"COMPUTED"`
 	K8s      *K8s       `json:"k8s,omitempty" yaml:"k8s" env:"K8S"`
-	Streams  Streams    `json:"streams" yaml:"streams" env:"STREAMS"`
 }
 
 type K8s struct {
@@ -54,7 +53,8 @@ type Table struct {
 	HashBy  string      `json:"hashBy,omitempty" yaml:"hashBy" env:"HASHBY"` // The column to use as key (metric), defaults to 'event'.
 	SortBy  string      `json:"sortBy,omitempty" yaml:"sortBy" env:"SORTBY"` // The column to use as time, defaults to 'tsi'.
 	Schema  string      `json:"schema" yaml:"schema" env:"SCHEMA"`           // The schema of the table
-	Compact *Compaction `json:"compact" yaml:"compact" env:"COMPACT"`
+	Compact *Compaction `json:"compact" yaml:"compact" env:"COMPACT"`        // The compaction configuration for the table
+	Streams Streams     `json:"streams" yaml:"streams" env:"STREAMS"`        // The streams to stream data to for data in this table
 }
 
 // Storage is the location to write the data

--- a/internal/config/env/configurer_test.go
+++ b/internal/config/env/configurer_test.go
@@ -78,6 +78,16 @@ tables:
       interval: 300
       file:
         dir: "output/"
+    streams:
+    - pubsub:
+        project: my-gcp-project
+        topic: my-topic
+        filter: "gcs://my-bucket/my-function.lua"
+        encoder: json
+    - pubsub:
+        project: my-gcp-project
+        topic: my-topic2
+        encoder: json
 statsd:
   host: "127.0.0.1"
   port: 8126
@@ -89,16 +99,6 @@ computed:
       function main(input)
         return json.encode(input)
       end
-streams:
-  - pubsub:
-      project: my-gcp-project
-      topic: my-topic
-      filter: "gcs://my-bucket/my-function.lua"
-      encoder: json
-  - pubsub:
-      project: my-gcp-project
-      topic: my-topic2
-      encoder: json
 `)
 
 	// populate the config with the env variable
@@ -106,10 +106,10 @@ streams:
 	assert.NoError(t, e.Configure(c))
 
 	// asserts
-	assert.Len(t, c.Streams, 2)
+	assert.Len(t, c.Tables["eventlog"].Streams, 2)
 	assert.Len(t, c.Computed, 1)
 	assert.Len(t, c.Tables, 1)
 
-	assert.Equal(t, "my-gcp-project", c.Streams[0].PubSub.Project)
+	assert.Equal(t, "my-gcp-project", c.Tables["eventlog"].Streams[0].PubSub.Project)
 	assert.Equal(t, "output/", c.Tables["eventlog"].Compact.File.Directory)
 }

--- a/internal/config/sample_config.yaml
+++ b/internal/config/sample_config.yaml
@@ -35,17 +35,17 @@ tables:
         project: "airasia-opdatalake-stg"
         dataset: "eventlog"
         table: "events"
+    streams:
+      - pubsub:
+          project: my-gcp-project
+          topic: my-topic
+          filter: "gcs://my-bucket/my-function.lua"
+          encoder: json
+      - pubsub:
+          project: my-gcp-project
+          topic: my-topic2
+          encoder: json
   users:
     hashBy: "user_id"
     sortBy: "ingested_at"
     schema: "gcs://k8s-default-stg-configs/ingestor/schema2.yaml"
-streams:
-  - pubsub:
-      project: my-gcp-project
-      topic: my-topic
-      filter: "gcs://my-bucket/my-function.lua"
-      encoder: json
-  - pubsub:
-      project: my-gcp-project
-      topic: my-topic2
-      encoder: json

--- a/internal/encoding/block/from_batch.go
+++ b/internal/encoding/block/from_batch.go
@@ -58,7 +58,7 @@ func FromBatchBy(batch *talaria.Batch, partitionBy string, filter *typeof.Schema
 			row.Set(columnName, columnValue)
 		}
 
-		// Append computed columns and fill nulls for the row
+		// Append computed columns
 		// Error can only be from encoding the row, error is logged in Publish() so we can ignore the error here and continue to convert row to columns
 		out, _ := apply(row)
 

--- a/internal/encoding/block/from_memory.go
+++ b/internal/encoding/block/from_memory.go
@@ -4,9 +4,9 @@
 package block
 
 import (
-	"github.com/kelindar/talaria/internal/column"
 	"github.com/kelindar/binary"
 	"github.com/kelindar/binary/nocopy"
+	"github.com/kelindar/talaria/internal/column"
 )
 
 // FromBuffer unmarshals a block from a in-memory buffer.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kelindar/talaria/internal/presto"
 	script "github.com/kelindar/talaria/internal/scripting"
 	"github.com/kelindar/talaria/internal/server/thriftlog"
-	"github.com/kelindar/talaria/internal/storage"
 	"github.com/kelindar/talaria/internal/table"
 	talaria "github.com/kelindar/talaria/proto"
 	"google.golang.org/grpc"
@@ -47,13 +46,12 @@ type Storage interface {
 // ------------------------------------------------------------------------------------------------------------
 
 // New creates a new talaria server.
-func New(conf config.Func, monitor monitor.Monitor, loader *script.Loader, streams storage.Streamer, tables ...table.Table) *Server {
+func New(conf config.Func, monitor monitor.Monitor, loader *script.Loader, tables ...table.Table) *Server {
 	const maxMessageSize = 32 * 1024 * 1024 // 32 MB
 	server := &Server{
 		server:  grpc.NewServer(grpc.MaxRecvMsgSize(maxMessageSize)),
 		conf:    conf,
 		monitor: monitor,
-		streams: streams,
 		tables:  make(map[string]table.Table),
 	}
 
@@ -90,7 +88,6 @@ type Server struct {
 	tables   map[string]table.Table // The list of tables
 	computed []column.Computed      // The set of computed columns
 	s3sqs    *s3sqs.Ingress         // The S3SQS Ingress (optional)
-	streams  storage.Streamer       // The streams to stream data to
 }
 
 // Listen starts listening on presto RPC & gRPC.

--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -35,7 +35,7 @@ func (s *Server) Ingest(ctx context.Context, request *talaria.IngestRequest) (*t
 		}
 
 		// Partition the request for the table
-		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, block.Transform(filter, s.computed...), stream.Publish(t.Streams, s.monitor))
+		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, block.Transform(filter, s.computed...), stream.Publish(t.GetStreams(), s.monitor))
 		if err != nil {
 			s.monitor.Count1(ctxTag, ingestErrorKey, "type:convert")
 			return nil, errors.Internal("unable to read the block", err)

--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -35,7 +35,7 @@ func (s *Server) Ingest(ctx context.Context, request *talaria.IngestRequest) (*t
 		}
 
 		// Partition the request for the table
-		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, block.Transform(filter, s.computed...), stream.Publish(s.streams, s.monitor))
+		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, block.Transform(filter, s.computed...), stream.Publish(t.Streams, s.monitor))
 		if err != nil {
 			s.monitor.Count1(ctxTag, ingestErrorKey, "type:convert")
 			return nil, errors.Internal("unable to read the block", err)

--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -10,10 +10,14 @@ import (
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/typeof"
 	"github.com/kelindar/talaria/internal/monitor/errors"
+	"github.com/kelindar/talaria/internal/storage"
 	"github.com/kelindar/talaria/internal/storage/stream"
 	"github.com/kelindar/talaria/internal/table"
 	talaria "github.com/kelindar/talaria/proto"
 )
+
+// applyFunc applies a transformation on a row and returns a new row
+type applyFunc = func(block.Row) (block.Row, error)
 
 const ingestErrorKey = "ingest.error"
 
@@ -34,8 +38,16 @@ func (s *Server) Ingest(ctx context.Context, request *talaria.IngestRequest) (*t
 			filter = &schema
 		}
 
+		// Functions to be applied
+		funcs := []applyFunc{block.Transform(filter, s.computed...)}
+
+		// If table supports streaming, add publishing function
+		if streamer, ok := t.(storage.Streamer); ok {
+			funcs = append(funcs, stream.Publish(streamer, s.monitor))
+		}
+
 		// Partition the request for the table
-		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, block.Transform(filter, s.computed...), stream.Publish(t.GetStreams(), s.monitor))
+		blocks, err := block.FromRequestBy(request, appender.HashBy(), filter, funcs...)
 		if err != nil {
 			s.monitor.Count1(ctxTag, ingestErrorKey, "type:convert")
 			return nil, errors.Internal("unable to read the block", err)

--- a/internal/storage/writer/azure/README.md
+++ b/internal/storage/writer/azure/README.md
@@ -1,14 +1,15 @@
 # Azure Blob Storage
 
-This sink implements Azure Blob Storage protocol. It can can be enabled by adding the following configuration in the `storage` section:
+This sink implements Azure Blob Storage protocol. It can can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    azure:                               # sink to use
-      container: "container-id-1"        # the container ID
-      prefix: ""                         # (optional) prefix to add
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      azure:                               # sink to use
+        container: "container-id-1"        # the container ID
+        prefix: ""                         # (optional) prefix to add
 ...
 ```

--- a/internal/storage/writer/bigquery/README.md
+++ b/internal/storage/writer/bigquery/README.md
@@ -1,15 +1,16 @@
 # Google Big Query
 
-This sink implements Google Big Query protocol. It can can be enabled by adding the following configuration in the `storage` section:
+This sink implements Google Big Query protocol. It can can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    bigquery:                            # sink to use
-      project: "project-id-1"            # project ID
-      dataset: "mydataset"               # big query dataset ID
-      table: "mytable"                   # big query table ID
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      bigquery:                            # sink to use
+        project: "project-id-1"            # project ID
+        dataset: "mydataset"               # big query dataset ID
+        table: "mytable"                   # big query table ID
 ...
 ```

--- a/internal/storage/writer/file/README.md
+++ b/internal/storage/writer/file/README.md
@@ -1,13 +1,14 @@
 # Google Cloud Storage
 
-This sink supports writing to the local file system. It can can be enabled by adding the following configuration in the `storage` section:
+This sink supports writing to the local file system. It can can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    file:                                # sink to use
-      dir: "/output"                     # the output directory
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      file:                                # sink to use
+        dir: "/output"                     # the output directory
 ...
 ```

--- a/internal/storage/writer/gcs/README.md
+++ b/internal/storage/writer/gcs/README.md
@@ -1,14 +1,15 @@
 # Google Cloud Storage
 
-This sink implements Google Cloud Storage protocol. It can can be enabled by adding the following configuration in the `storage` section:
+This sink implements Google Cloud Storage protocol. It can can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    gcs:                                  # sink to use
-      bucket: "bucket"                   # the bucket to use
-      prefix: "dir1/"                    # (optional) prefix to add
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      gcs:                                  # sink to use
+        bucket: "bucket"                   # the bucket to use
+        prefix: "dir1/"                    # (optional) prefix to add
 ...
 ```

--- a/internal/storage/writer/pubsub/README.md
+++ b/internal/storage/writer/pubsub/README.md
@@ -1,0 +1,15 @@
+# Google Pub/Sub sink
+
+This sink implements Google Pub/Sub protocol. It only works for streams, not for compaction like the other sinks. It can can be enabled by adding the following configuration in the `tables` section:
+
+```yaml
+tables:
+  eventlog:
+    streams:
+      - pubsub:
+          project: my-gcp-project
+          topic: my-topic
+          filter: "gcs://my-bucket/my-function.lua"
+          encoder: json
+...
+```

--- a/internal/storage/writer/s3/README.md
+++ b/internal/storage/writer/s3/README.md
@@ -2,21 +2,22 @@
 
 This sink implements Amazon S3 protocol and can be enabled for Digital Ocean Spaces and Minio using a custom `endpoint`.
 
-This sink can be enabled by adding the following configuration in the `storage` section:
+This sink can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    s3:                                  # sink to Amazon S3
-      region: "ap-southeast-1"           # the region to use
-      bucket: "bucket"                   # the bucket to use
-      prefix: "dir1/"                    # (optional) prefix to add
-      endpoint: "http://127.0.0.1"       # (optional) custom endpoint to use
-      sse: ""                            # (optional) server-side encryption
-      accessKey: ""                      # (optional) static access key to override
-      secretKey: ""                      # (optional) static secret key to override
-      concurrency: 32                    # (optional) upload concurrency, default=NUM_CPU
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      s3:                                  # sink to Amazon S3
+        region: "ap-southeast-1"           # the region to use
+        bucket: "bucket"                   # the bucket to use
+        prefix: "dir1/"                    # (optional) prefix to add
+        endpoint: "http://127.0.0.1"       # (optional) custom endpoint to use
+        sse: ""                            # (optional) server-side encryption
+        accessKey: ""                      # (optional) static access key to override
+        secretKey: ""                      # (optional) static secret key to override
+        concurrency: 32                    # (optional) upload concurrency, default=NUM_CPU
 ...
 ```

--- a/internal/storage/writer/talaria/README.md
+++ b/internal/storage/writer/talaria/README.md
@@ -2,17 +2,18 @@
 
 This sink implements sending data to a second Talaria. It can be used when there is one Talaria for **event ingestion**, and needs to write data to a second Talaria, which is used **purely for querying data.**
 
-This sink can be enabled by adding the following configuration in the `storage` section:
+This sink can be enabled by adding the following configuration in the `tables` section:
 
 ```yaml
-storage:
-  compact:                               # enable compaction
-    interval: 60                         # compact every 60 seconds
-    nameFunc: "s3://bucket/namefunc.lua" # file name function
-    talaria:                             # sink to Talaria
-      endpoint: "127.0.0.1:8043"         # Talaria endpoint to write data to
-      timeout: 5                         # Timeout for requests to Talaria
-      maxConcurrent: 10                  # Number of concurrent requests to Talaria
-      errorThreshold: 50                 # Percentage of errors before no more requests are sent
+tables:
+  eventlog:
+    compact:                               # enable compaction
+      interval: 60                         # compact every 60 seconds
+      nameFunc: "s3://bucket/namefunc.lua" # file name function
+      talaria:                             # sink to Talaria
+        endpoint: "127.0.0.1:8043"         # Talaria endpoint to write data to
+        timeout: 5                         # Timeout for requests to Talaria
+        maxConcurrent: 10                  # Number of concurrent requests to Talaria
+        errorThreshold: 50                 # Percentage of errors before no more requests are sent
 ...
 ```

--- a/internal/table/log/log.go
+++ b/internal/table/log/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kelindar/talaria/internal/monitor"
 	"github.com/kelindar/talaria/internal/monitor/logging"
 	"github.com/kelindar/talaria/internal/storage/disk"
+	"github.com/kelindar/talaria/internal/storage/writer"
 	"github.com/kelindar/talaria/internal/table"
 	"github.com/kelindar/talaria/internal/table/timeseries"
 )
@@ -39,12 +40,16 @@ func New(cfg config.Func, cluster Membership, monitor monitor.Monitor) *Table {
 
 	// Open a dedicated logs storage
 	store := disk.Open(cfg().Storage.Directory, name, monitor, cfg().Storage.Badger)
+
+	// Create a noop streamer
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor, nil)
+
 	base := timeseries.New(name, cluster, monitor, store, &config.Table{
 		TTL:    24 * 3600, // 1 day
 		SortBy: "time",
 		HashBy: "",
 		Schema: "",
-	})
+	}, streams)
 	return &Table{
 		Table:   *base,
 		cluster: cluster,

--- a/internal/table/nodes/nodes.go
+++ b/internal/table/nodes/nodes.go
@@ -11,12 +11,8 @@ import (
 	"github.com/emitter-io/address"
 	"github.com/hako/durafmt"
 	"github.com/kelindar/talaria/internal/column"
-	"github.com/kelindar/talaria/internal/config"
 	"github.com/kelindar/talaria/internal/encoding/typeof"
-	"github.com/kelindar/talaria/internal/monitor"
 	"github.com/kelindar/talaria/internal/presto"
-	"github.com/kelindar/talaria/internal/storage"
-	"github.com/kelindar/talaria/internal/storage/writer"
 	"github.com/kelindar/talaria/internal/table"
 )
 
@@ -34,20 +30,15 @@ type Membership interface {
 
 // Table represents a nodes table.
 type Table struct {
-	cluster   Membership       // The membership list to use
-	startedAt time.Time        // The time when the node was started
-	streams   storage.Streamer // The streamer for this table
+	cluster   Membership // The membership list to use
+	startedAt time.Time  // The time when the node was started
 }
 
 // New creates a new table implementation.
 func New(cluster Membership) *Table {
-	// Create a noop streamer
-	streams, _ := writer.ForStreaming(config.Streams{}, monitor.NewNoop(), nil)
-
 	return &Table{
 		cluster:   cluster,
 		startedAt: time.Now(),
-		streams:   streams,
 	}
 }
 
@@ -81,11 +72,6 @@ func (t *Table) HashBy() string {
 // SortBy returns the column by which the table should be sorted.
 func (t *Table) SortBy() string {
 	return "address"
-}
-
-// GetStreams will return noop streamer for nodes
-func (t *Table) GetStreams() storage.Streamer {
-	return t.streams
 }
 
 // GetSplits retrieves the splits

--- a/internal/table/nodes/nodes.go
+++ b/internal/table/nodes/nodes.go
@@ -11,8 +11,12 @@ import (
 	"github.com/emitter-io/address"
 	"github.com/hako/durafmt"
 	"github.com/kelindar/talaria/internal/column"
+	"github.com/kelindar/talaria/internal/config"
 	"github.com/kelindar/talaria/internal/encoding/typeof"
+	"github.com/kelindar/talaria/internal/monitor"
 	"github.com/kelindar/talaria/internal/presto"
+	"github.com/kelindar/talaria/internal/storage"
+	"github.com/kelindar/talaria/internal/storage/writer"
 	"github.com/kelindar/talaria/internal/table"
 )
 
@@ -30,15 +34,20 @@ type Membership interface {
 
 // Table represents a nodes table.
 type Table struct {
-	cluster   Membership // The membership list to use
-	startedAt time.Time  // The time when the node was started
+	cluster   Membership       // The membership list to use
+	startedAt time.Time        // The time when the node was started
+	streams   storage.Streamer // The streamer for this table
 }
 
 // New creates a new table implementation.
 func New(cluster Membership) *Table {
+	// Create a noop streamer
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor.NewNoop(), nil)
+
 	return &Table{
 		cluster:   cluster,
 		startedAt: time.Now(),
+		streams:   streams,
 	}
 }
 
@@ -72,6 +81,11 @@ func (t *Table) HashBy() string {
 // SortBy returns the column by which the table should be sorted.
 func (t *Table) SortBy() string {
 	return "address"
+}
+
+// GetStreams will return noop streamer for nodes
+func (t *Table) GetStreams() storage.Streamer {
+	return t.streams
 }
 
 // GetSplits retrieves the splits

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/typeof"
 	"github.com/kelindar/talaria/internal/presto"
+	"github.com/kelindar/talaria/internal/storage"
 )
 
 // Errors commonly occuring in tables
@@ -26,6 +27,7 @@ type Table interface {
 	GetRows(splitID []byte, columns []string, maxBytes int64) (*PageResult, error)
 	HashBy() string
 	SortBy() string
+	GetStreams() storage.Streamer
 }
 
 // Appender represents an appender of data to the table.

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/typeof"
 	"github.com/kelindar/talaria/internal/presto"
-	"github.com/kelindar/talaria/internal/storage"
 )
 
 // Errors commonly occuring in tables
@@ -27,7 +26,6 @@ type Table interface {
 	GetRows(splitID []byte, columns []string, maxBytes int64) (*PageResult, error)
 	HashBy() string
 	SortBy() string
-	GetStreams() storage.Streamer
 }
 
 // Appender represents an appender of data to the table.

--- a/internal/table/timeseries/timeseries.go
+++ b/internal/table/timeseries/timeseries.go
@@ -52,11 +52,11 @@ type Table struct {
 	cluster      Membership       // The membership list to use
 	monitor      monitor.Monitor  // The monitoring client
 	staticSchema *typeof.Schema   // The static schema of the timeseries table
-	streams      storage.Streamer // The streams that a table has
+	stream       storage.Streamer // The streams that a table has
 }
 
 // New creates a new table implementation.
-func New(name string, cluster Membership, monitor monitor.Monitor, store storage.Storage, cfg *config.Table, streams storage.Streamer) *Table {
+func New(name string, cluster Membership, monitor monitor.Monitor, store storage.Storage, cfg *config.Table, stream storage.Streamer) *Table {
 	t := &Table{
 		name:    name,
 		store:   store,
@@ -66,7 +66,7 @@ func New(name string, cluster Membership, monitor monitor.Monitor, store storage
 		cluster: cluster,
 		monitor: monitor,
 		loader:  loader.New(),
-		streams: streams,
+		stream:  stream,
 	}
 
 	t.staticSchema = t.loadStaticSchema(cfg.Schema)
@@ -98,9 +98,9 @@ func (t *Table) SortBy() string {
 	return t.sortBy
 }
 
-// GetStreams will return the streamers for the table
-func (t *Table) GetStreams() storage.Streamer {
-	return t.streams
+// Stream will stream the row and return errors if any
+func (t *Table) Stream(row block.Row) error {
+	return t.stream.Stream(row)
 }
 
 func (t *Table) loadStaticSchema(uriOrSchema string) *typeof.Schema {

--- a/internal/table/timeseries/timeseries.go
+++ b/internal/table/timeseries/timeseries.go
@@ -52,7 +52,7 @@ type Table struct {
 	cluster      Membership       // The membership list to use
 	monitor      monitor.Monitor  // The monitoring client
 	staticSchema *typeof.Schema   // The static schema of the timeseries table
-	Streams      storage.Streamer // The streams that a table has
+	streams      storage.Streamer // The streams that a table has
 }
 
 // New creates a new table implementation.
@@ -66,7 +66,7 @@ func New(name string, cluster Membership, monitor monitor.Monitor, store storage
 		cluster: cluster,
 		monitor: monitor,
 		loader:  loader.New(),
-		Streams: streams,
+		streams: streams,
 	}
 
 	t.staticSchema = t.loadStaticSchema(cfg.Schema)
@@ -96,6 +96,11 @@ func (t *Table) HashBy() string {
 // SortBy returns the column by which the table should be sorted.
 func (t *Table) SortBy() string {
 	return t.sortBy
+}
+
+// GetStreams will return the streamers for the table
+func (t *Table) GetStreams() storage.Streamer {
+	return t.streams
 }
 
 func (t *Table) loadStaticSchema(uriOrSchema string) *typeof.Schema {

--- a/internal/table/timeseries/timeseries.go
+++ b/internal/table/timeseries/timeseries.go
@@ -42,20 +42,21 @@ type Membership interface {
 
 // Table represents a timeseries table.
 type Table struct {
-	name         string          // The name of the table
-	hashBy       string          // The name of the key column
-	sortBy       string          // The name of the time column
-	ttl          time.Duration   // The default TTL
-	store        storage.Storage // The storage to use
-	schema       atomic.Value    // The latest schema
-	loader       *loader.Loader  // The loader used to watch schema updates
-	cluster      Membership      // The membership list to use
-	monitor      monitor.Monitor // The monitoring client
-	staticSchema *typeof.Schema  // The static schema of the timeseries table
+	name         string           // The name of the table
+	hashBy       string           // The name of the key column
+	sortBy       string           // The name of the time column
+	ttl          time.Duration    // The default TTL
+	store        storage.Storage  // The storage to use
+	schema       atomic.Value     // The latest schema
+	loader       *loader.Loader   // The loader used to watch schema updates
+	cluster      Membership       // The membership list to use
+	monitor      monitor.Monitor  // The monitoring client
+	staticSchema *typeof.Schema   // The static schema of the timeseries table
+	Streams      storage.Streamer // The streams that a table has
 }
 
 // New creates a new table implementation.
-func New(name string, cluster Membership, monitor monitor.Monitor, store storage.Storage, cfg *config.Table) *Table {
+func New(name string, cluster Membership, monitor monitor.Monitor, store storage.Storage, cfg *config.Table, streams storage.Streamer) *Table {
 	t := &Table{
 		name:    name,
 		store:   store,
@@ -65,6 +66,7 @@ func New(name string, cluster Membership, monitor monitor.Monitor, store storage
 		cluster: cluster,
 		monitor: monitor,
 		loader:  loader.New(),
+		Streams: streams,
 	}
 
 	t.staticSchema = t.loadStaticSchema(cfg.Schema)

--- a/internal/table/timeseries/timeseries_test.go
+++ b/internal/table/timeseries/timeseries_test.go
@@ -14,6 +14,7 @@ import (
 	monitor2 "github.com/kelindar/talaria/internal/monitor"
 	"github.com/kelindar/talaria/internal/presto"
 	"github.com/kelindar/talaria/internal/storage/disk"
+	"github.com/kelindar/talaria/internal/storage/writer"
 	"github.com/kelindar/talaria/internal/table/timeseries"
 	"github.com/stretchr/testify/assert"
 )
@@ -55,9 +56,10 @@ func TestTimeseries_DynamicSchema(t *testing.T) {
 
 	monitor := monitor2.NewNoop()
 	store := disk.Open(dir, name, monitor, config.Badger{})
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor, nil)
 
 	// Start the server and open the database
-	eventlog := timeseries.New(name, new(noopMembership), monitor, store, &tableConf)
+	eventlog := timeseries.New(name, new(noopMembership), monitor, store, &tableConf, streams)
 	assert.NotNil(t, eventlog)
 	assert.Equal(t, name, eventlog.Name())
 	defer eventlog.Close()
@@ -148,9 +150,10 @@ int1: int64
 
 	monitor := monitor2.NewNoop()
 	store := disk.Open(dir, name, monitor, config.Badger{})
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor, nil)
 
 	// Start the server and open the database
-	eventlog := timeseries.New(name, new(noopMembership), monitor, store, &tableConf)
+	eventlog := timeseries.New(name, new(noopMembership), monitor, store, &tableConf, streams)
 	defer eventlog.Close()
 
 	actualSchema, isStatic := eventlog.Schema()

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -61,6 +61,7 @@ func BenchmarkQuery(b *testing.B) {
 	// create monitor
 	monitor := monitor.NewNoop()
 	store := disk.Open(cfg().Storage.Directory, tableName, monitor, cfg().Storage.Badger)
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor, script.NewLoader(nil))
 
 	// Start the server and open the database
 	eventlog := timeseries.New(tableName, new(noopMembership), monitor, store, &config.Table{
@@ -68,10 +69,9 @@ func BenchmarkQuery(b *testing.B) {
 		HashBy: cfg().Tables[tableName].HashBy,
 		SortBy: cfg().Tables[tableName].SortBy,
 		Schema: "",
-	})
+	}, streams)
 
-	streams, _ := writer.ForStreaming(nil, monitor, script.NewLoader(nil))
-	server := server.New(cfg, monitor, script.NewLoader(nil), streams, eventlog)
+	server := server.New(cfg, monitor, script.NewLoader(nil), eventlog)
 	defer server.Close()
 
 	// Append some files

--- a/test/local.go
+++ b/test/local.go
@@ -69,6 +69,7 @@ func main() {
 	gossip.JoinHostname("localhost")
 
 	store := disk.Open(cfg().Storage.Directory, tableName, monitor, config.Badger{})
+	streams, _ := writer.ForStreaming(config.Streams{}, monitor, script.NewLoader(nil))
 
 	// Start the server and open the database
 	eventlog := timeseries.New(tableName, gossip, monitor, store, &config.Table{
@@ -76,10 +77,9 @@ func main() {
 		HashBy: cfg().Tables[tableName].HashBy,
 		SortBy: cfg().Tables[tableName].SortBy,
 		Schema: "",
-	})
+	}, streams)
 
-	streams, _ := writer.ForStreaming(nil, monitor, script.NewLoader(nil))
-	server := server.New(cfg, monitor, script.NewLoader(nil), streams,
+	server := server.New(cfg, monitor, script.NewLoader(nil),
 		eventlog,
 		nodes.New(gossip),
 	)


### PR DESCRIPTION
To fix #48, where events will be streamed multiple time to the same topics if there's more than one table.

1. Streams are fixed at table level
2. Documentation updated to reflect configuration changes for tables, compaction and streaming