### PR TITLE
Fix substreaming not starting

### DIFF
--- a/internal/storage/writer/base/base.go
+++ b/internal/storage/writer/base/base.go
@@ -68,14 +68,14 @@ func newWithEncoder(name string, filter *lua.Script, encoder Func) (*Writer, err
 }
 
 // Run task to process work using async invoke
-func (w *Writer) Run(ctx context.Context) async.Task {
+func (w *Writer) Run(ctx context.Context) (async.Task, error) {
 	if w.Process == nil {
-		return nil
+		return nil, errors.New("base: no process defined for this stream")
 	}
 	w.task = async.Invoke(ctx, func(innerctx context.Context) (interface{}, error) {
 		return nil, w.Process(innerctx)
 	})
-	return w.task
+	return w.task, nil
 }
 
 // Close invoked task

--- a/internal/storage/writer/multi/multi.go
+++ b/internal/storage/writer/multi/multi.go
@@ -3,6 +3,7 @@ package multi
 import (
 	"context"
 
+	"github.com/grab/async"
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/key"
 )
@@ -15,7 +16,7 @@ type SubWriter interface {
 // streamer represents the sub-streamer
 type streamer interface {
 	Stream(row block.Row) error
-	Run(ctx context.Context)
+	Run(ctx context.Context) (async.Task, error)
 }
 
 // Writer represents a writer that writes into multiple sub-writers.
@@ -51,11 +52,14 @@ func (w *Writer) Write(key key.Key, val []byte) error {
 }
 
 // Run launches a goroutine to start the infinite loop for streaming
-func (w *Writer) Run(ctx context.Context) {
+func (w *Writer) Run(ctx context.Context) (async.Task, error) {
 	for _, w := range w.streamers {
-		w.Run(ctx)
+		_, err := w.Run(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return
+	return nil, nil
 }
 
 // Stream streams the data to the sink

--- a/internal/storage/writer/multi/multi.go
+++ b/internal/storage/writer/multi/multi.go
@@ -51,7 +51,7 @@ func (w *Writer) Write(key key.Key, val []byte) error {
 	return nil
 }
 
-// Run launches a goroutine to start the infinite loop for streaming
+// Run launches the asynchronous infinite loop for streamers to start streaming data
 func (w *Writer) Run(ctx context.Context) (async.Task, error) {
 	for _, w := range w.streamers {
 		_, err := w.Run(ctx)

--- a/internal/storage/writer/multi/multi_test.go
+++ b/internal/storage/writer/multi/multi_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grab/async"
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/key"
 	"github.com/stretchr/testify/assert"
@@ -29,8 +30,8 @@ func (w *MockWriterFull) Stream(block.Row) error {
 	return nil
 }
 
-func (w *MockWriterFull) Run(ctx context.Context) {
-	return
+func (w *MockWriterFull) Run(ctx context.Context) (async.Task, error) {
+	return nil, nil
 }
 
 func TestMulti(t *testing.T) {

--- a/internal/storage/writer/multi/multi_test.go
+++ b/internal/storage/writer/multi/multi_test.go
@@ -49,6 +49,7 @@ func TestMulti(t *testing.T) {
 	mock2 := MockWriterFull{Count: 5}
 
 	multiWriter2 := New(&mock1, &mock2)
+	multiWriter2.Run(context.Background())
 	res := multiWriter2.Stream(block.Row{})
 
 	assert.NoError(t, res)

--- a/internal/storage/writer/pubsub/pubsub_test.go
+++ b/internal/storage/writer/pubsub/pubsub_test.go
@@ -60,7 +60,8 @@ func TestNew(t *testing.T) {
 	//process() should display error message but continues on
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	c.Run(ctx).Outcome()
+	task, _ := c.Run(ctx)
+	task.Outcome()
 
 	// Give some time for process to run in the background goroutine
 	assert.Empty(t, c.buffer)

--- a/internal/storage/writer/writer.go
+++ b/internal/storage/writer/writer.go
@@ -168,8 +168,8 @@ func newStreamer(config config.Streams, monitor monitor.Monitor, loader *script.
 
 	// Setup a multi-writer for all configured writers
 	multiWriters := multi.New(writers...)
-	multiWriters.Run(context.Background())
-	return multiWriters, nil
+	_, err := multiWriters.Run(context.Background())
+	return multiWriters, err
 }
 
 // defaultNameFunc represents a default name function


### PR DESCRIPTION
To fix a bug in #48, where the return values of Run() in multi-writer does not match the one in base writer. This caused the streams to be unable to start running.

Also propagated errors from Run() to log it.