### PR TITLE
Fix/random map event

### DIFF
--- a/client/golang/encoding.go
+++ b/client/golang/encoding.go
@@ -116,6 +116,13 @@ func (e *encoder) encodeValue(v interface{}) (*pb.Value, error) {
 	case json.RawMessage:
 		valueRef := e.updateDict(string(val))
 		return &pb.Value{Value: &pb.Value_Json{Json: valueRef}}, nil
+	case map[string]interface{}:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return nil, err
+		}
+		valueRef := e.updateDict(string(b))
+		return &pb.Value{Value: &pb.Value_Json{Json: valueRef}}, nil
 	case nil: // The field is not set.
 		return nil, nil
 	default:

--- a/client/golang/encoding.go
+++ b/client/golang/encoding.go
@@ -116,7 +116,7 @@ func (e *encoder) encodeValue(v interface{}) (*pb.Value, error) {
 	case json.RawMessage:
 		valueRef := e.updateDict(string(val))
 		return &pb.Value{Value: &pb.Value_Json{Json: valueRef}}, nil
-	case map[string]interface{}:
+	case map[string]interface{}: // If a map is provided, it is converted to json string before encoding.
 		b, err := json.Marshal(val)
 		if err != nil {
 			return nil, err

--- a/client/golang/encoding_test.go
+++ b/client/golang/encoding_test.go
@@ -69,4 +69,5 @@ func TestEncoder(t *testing.T) {
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{5: {Value: &pb.Value_Time{Time: testTime.Unix()}}}}, res.Events[3])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{6: {Value: &pb.Value_Json{Json: 7}}}}, res.Events[4])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{6: {Value: &pb.Value_String_{String_: 8}}}}, res.Events[5])
+	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{1: {Value: &pb.Value_String_{String_: 9}}, 14: {Value: &pb.Value_Json{Json: 15}}}}, res.Events[7])
 }

--- a/client/golang/encoding_test.go
+++ b/client/golang/encoding_test.go
@@ -43,12 +43,26 @@ func TestEncoder(t *testing.T) {
 			"color": "yellow",
 			"topic": "movie",
 		},
+		{
+			"event": "xyz",
+			"nested": map[string]interface{}{
+				"level0": 0,
+				"level1": map[string]interface{}{
+					"test": 1,
+					"level2": []int{
+						1,
+						2,
+						3,
+					},
+				},
+			},
+		},
 	}
 
 	encoder := newEncoder()
 	res := encoder.Encode(testEvents)
-	assert.Len(t, res.Events, 7)
-	assert.Len(t, res.Strings, 13)
+	assert.Len(t, res.Events, 8)
+	assert.Len(t, res.Strings, 15)
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{1: {Value: &pb.Value_String_{String_: 2}}}}, res.Events[0])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{3: {Value: &pb.Value_Int64{Int64: 123}}}}, res.Events[1])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{4: {Value: &pb.Value_Bool{Bool: true}}}}, res.Events[2])


### PR DESCRIPTION
if a map is provided as an event, the event is converted to json string and gets encoded as json raw message.