### PR TITLE
Update crphang/orc to include fix for Double reader

### DIFF
--- a/client/golang/encoding_test.go
+++ b/client/golang/encoding_test.go
@@ -44,7 +44,7 @@ func TestEncoder(t *testing.T) {
 			"topic": "movie",
 		},
 		{
-			"event": "xyz",
+			"event": "abc",
 			"nested": map[string]interface{}{
 				"level0": 0,
 				"level1": map[string]interface{}{
@@ -69,5 +69,5 @@ func TestEncoder(t *testing.T) {
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{5: {Value: &pb.Value_Time{Time: testTime.Unix()}}}}, res.Events[3])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{6: {Value: &pb.Value_Json{Json: 7}}}}, res.Events[4])
 	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{6: {Value: &pb.Value_String_{String_: 8}}}}, res.Events[5])
-	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{1: {Value: &pb.Value_String_{String_: 9}}, 14: {Value: &pb.Value_Json{Json: 15}}}}, res.Events[7])
+	assert.Equal(t, &pb.Event{Value: map[uint32]*pb.Value{1: {Value: &pb.Value_String_{String_: 2}}, 14: {Value: &pb.Value_Json{Json: 15}}}}, res.Events[7])
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/armon/go-metrics v0.3.3 // indirect
 	github.com/aws/aws-sdk-go v1.30.25
-	github.com/crphang/orc v0.0.3
+	github.com/crphang/orc v0.0.6
 	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200626160443-3042e3776798
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/crphang/orc v0.0.3 h1:izgRzMsYn7vjkBKA33mN60qpBW8w8nLEDbnmQpSS95A=
 github.com/crphang/orc v0.0.3/go.mod h1:+siY09J77eYa8+0+UXZxeyv8nrmhvOY40DbqB7gRVhU=
+github.com/crphang/orc v0.0.6 h1:wcmX6/Lg9YSxflFS+vpuQBoOUQv1ixE8Ihxmm4eQFxI=
+github.com/crphang/orc v0.0.6/go.mod h1:+siY09J77eYa8+0+UXZxeyv8nrmhvOY40DbqB7gRVhU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Table struct {
 
 // Storage is the location to write the data
 type Storage struct {
-	Badger `yaml:",inline"`
+	Badger
 	Directory string `json:"dir" yaml:"dir" env:"DIR"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Table struct {
 
 // Storage is the location to write the data
 type Storage struct {
-	Badger
+	Badger `yaml:",inline"`
 	Directory string `json:"dir" yaml:"dir" env:"DIR"`
 }
 


### PR DESCRIPTION
1. upgrade crphang/orc version to include fix for Double reader
2. fix flaky test due to unstable iteration of map when encoding