### PR TITLE
Client Support for Parquet Ingestion

### DIFF
--- a/client/golang/client.go
+++ b/client/golang/client.go
@@ -147,6 +147,18 @@ func (c *Client) IngestORC(ctx context.Context, data []byte) error {
 	}, nil)
 }
 
+// IngestParquet sends an Parquet-encoded file to Talaria to ingest.
+func (c *Client) IngestParquet(ctx context.Context, data []byte) error {
+	return hystrix.Do(commandName, func() error {
+		_, err := c.ingress.Ingest(ctx, &pb.IngestRequest{
+			Data: &pb.IngestRequest_Parquet{
+				Parquet: data,
+			},
+		})
+		return err
+	}, nil)
+}
+
 // Close connection
 func (c *Client) Close() error {
 	return c.conn.Close()

--- a/client/python/talaria_client/client.py
+++ b/client/python/talaria_client/client.py
@@ -28,3 +28,7 @@ class Client:
     def ingest_orc(self, orc_data):
         ingest_req = talaria_pb2.IngestRequest(orc=orc_data)
         return self.ingress.Ingest(ingest_req)
+
+    def ingest_parquet(self, parquet_data):
+        ingest_req = talaria_pb2.IngestRequest(parquet=parquet_data)
+        return self.ingress.Ingest(ingest_req)


### PR DESCRIPTION
This commit introduces support for Parquet ingestion in Golang and Python clients