### PR TITLE
Make encoder configurable for the compaction

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -407,6 +408,7 @@ golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vK
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 h1:cg5LA/zNPRzIXIWSCxQW10Rvpy94aQh3LT/ShoCpkHw=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -488,6 +490,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,7 @@ type Computed struct {
 // Compaction represents a configuration for compaction sinks
 type Compaction struct {
 	Sinks    `yaml:",inline"`
+	Encoder  string `json:"encoder" yaml:"encoder"`                  // The default encoder for the compaction
 	NameFunc string `json:"nameFunc" yaml:"nameFunc" env:"NAMEFUNC"` // The lua script to compute file name given a row
 	Interval int    `json:"interval" yaml:"interval" env:"INTERVAL"` // The compaction interval, in seconds
 }

--- a/internal/config/sample_config.yaml
+++ b/internal/config/sample_config.yaml
@@ -27,6 +27,7 @@ tables:
     schema: "gcs://k8s-default-stg-configs/ingestor/schema1.yaml"
     compact:
       interval: 60
+      encoder: orc
       nameFunc: "gcs://k8s-online-stg-configs/ingestor/name.lua"
       gcs:
         bucket: "airasia-opdatalake-stg-datalake"

--- a/internal/encoding/merge/merge.go
+++ b/internal/encoding/merge/merge.go
@@ -1,0 +1,53 @@
+package merge
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+
+	"github.com/kelindar/talaria/internal/encoding/block"
+	"github.com/kelindar/talaria/internal/encoding/typeof"
+	"github.com/kelindar/talaria/internal/monitor/errors"
+)
+
+// Func represents merge function
+type Func func([]block.Block, typeof.Schema) ([]byte, error)
+
+// New creates a new merge function
+func New(mergeFunc string) (Func, error) {
+	switch strings.ToLower(mergeFunc) {
+	case "orc":
+		return ToOrc, nil
+	case "": // Default to "orc" so we don't break existing configs
+		return ToOrc, nil
+	}
+
+	return nil, errors.Newf("unsupported merge function %v", mergeFunc)
+}
+
+// ----------------------------------------------------------------------------
+
+// Clone clones the buffer into one which can be returned
+func clone(b *bytes.Buffer) []byte {
+	output := make([]byte, len(b.Bytes()))
+	copy(output, b.Bytes())
+	return output
+}
+
+// A memory pool for reusable temporary buffers
+var buffers = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 16*1<<20))
+	},
+}
+
+// Acquire gets a buffer from the pool
+func acquire() *bytes.Buffer {
+	return buffers.Get().(*bytes.Buffer)
+}
+
+// Release releases the buffer back to the pool
+func release(buffer *bytes.Buffer) {
+	buffer.Reset()
+	buffers.Put(buffer)
+}

--- a/internal/encoding/merge/merge_test.go
+++ b/internal/encoding/merge/merge_test.go
@@ -1,0 +1,51 @@
+package merge
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/kelindar/binary"
+	"github.com/kelindar/talaria/internal/encoding/block"
+	"github.com/stretchr/testify/assert"
+)
+
+// BenchmarkFlush runs a benchmark for a Merge function for flushing
+// To run it, go in the directory and do 'go test -benchmem -bench=. -benchtime=1s'
+// BenchmarkMerge/orc-8         	       1	7195029600 ns/op	2101578032 B/op	36859501 allocs/op
+func BenchmarkMerge(b *testing.B) {
+
+	// Append some files
+	blksData, _ := ioutil.ReadFile(testBlockFile)
+	blocks := make([]block.Block, 0)
+	_ = binary.Unmarshal(blksData, &blocks)
+
+	// Run the actual benchmark
+	b.Run("orc", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			ToOrc(blocks, blocks[0].Schema())
+		}
+	})
+}
+
+func TestMergeNew(t *testing.T) {
+
+	{
+		o, err := New("orc")
+		assert.NotNil(t, o)
+		assert.NoError(t, err)
+	}
+
+	{
+		o, err := New("")
+		assert.NotNil(t, o)
+		assert.NoError(t, err)
+	}
+
+	{
+		o, err := New("xxx")
+		assert.Nil(t, o)
+		assert.Error(t, err)
+	}
+}

--- a/internal/encoding/merge/orc.go
+++ b/internal/encoding/merge/orc.go
@@ -1,0 +1,72 @@
+package merge
+
+import (
+	"compress/flate"
+
+	eorc "github.com/crphang/orc"
+	"github.com/kelindar/talaria/internal/column"
+	"github.com/kelindar/talaria/internal/encoding/block"
+	"github.com/kelindar/talaria/internal/encoding/orc"
+	"github.com/kelindar/talaria/internal/encoding/typeof"
+	"github.com/kelindar/talaria/internal/monitor/errors"
+)
+
+// ToOrc merges multiple blocks together and outputs a key and merged orc data
+func ToOrc(blocks []block.Block, schema typeof.Schema) ([]byte, error) {
+	orcSchema, err := orc.SchemaFor(schema)
+	if err != nil {
+		return nil, errors.Internal("merge: error generating orc schema", err)
+	}
+
+	// Acquire a buffer to be used during the merging process
+	buffer := acquire()
+	defer release(buffer)
+
+	// Create a new writer
+	writer, err := eorc.NewWriter(buffer,
+		eorc.SetSchema(orcSchema),
+		eorc.SetCompression(eorc.CompressionZlib{Level: flate.DefaultCompression}))
+
+	for _, blk := range blocks {
+		rows, err := blk.Select(blk.Schema())
+		if err != nil {
+			continue
+		}
+
+		// Fetch columns that is required by the static schema
+		cols := make(column.Columns, 16)
+		for name, typ := range schema {
+			col, ok := rows[name]
+			if !ok || col.Kind() != typ {
+				col = column.NewColumn(typ)
+			}
+
+			cols[name] = col
+		}
+
+		cols.FillNulls()
+
+		allCols := []column.Column{}
+		for _, colName := range schema.Columns() {
+			allCols = append(allCols, cols[colName])
+		}
+
+		for i := 0; i < allCols[0].Count(); i++ {
+			row := []interface{}{}
+			for j := 0; j < len(allCols); j++ {
+				row = append(row, allCols[j].At(i))
+			}
+			if err := writer.Write(row...); err != nil {
+				//return nil, errors.Internal("flush: error writing row", err)
+				// TODO: should we ignore or continue?
+			}
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, errors.Internal("flush: error closing writer", err)
+	}
+
+	// Always return a cloned buffer since we're reusing the working one
+	return clone(buffer), nil
+}

--- a/internal/encoding/merge/orc_test.go
+++ b/internal/encoding/merge/orc_test.go
@@ -1,0 +1,134 @@
+// Copyright 2019-2020 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+
+package merge
+
+import (
+	"bytes"
+	"compress/flate"
+	"testing"
+
+	eorc "github.com/crphang/orc"
+	"github.com/kelindar/talaria/internal/encoding/block"
+	"github.com/kelindar/talaria/internal/encoding/orc"
+	"github.com/kelindar/talaria/internal/encoding/typeof"
+	"github.com/stretchr/testify/assert"
+)
+
+const testBlockFile = "../../../test/testBlocks"
+
+func TestToOrc(t *testing.T) {
+
+	schema := typeof.Schema{
+		"col0": typeof.String,
+		"col1": typeof.Int64,
+		"col2": typeof.Float64,
+	}
+	orcSchema, err := orc.SchemaFor(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orcBuffer1 := &bytes.Buffer{}
+	writer, _ := eorc.NewWriter(orcBuffer1,
+		eorc.SetSchema(orcSchema))
+	_ = writer.Write("eventName", 1, 1.0)
+	_ = writer.Close()
+
+	orcBuffer2 := &bytes.Buffer{}
+	writer, _ = eorc.NewWriter(orcBuffer2,
+		eorc.SetSchema(orcSchema))
+	_ = writer.Write("eventName", 2, 2.0)
+	_ = writer.Close()
+
+	apply := block.Transform(nil)
+
+	block1, err := block.FromOrcBy(orcBuffer1.Bytes(), "col0", nil, apply)
+	block2, err := block.FromOrcBy(orcBuffer2.Bytes(), "col0", nil, apply)
+
+	mergedBlocks := []block.Block{}
+	for _, blk := range block1 {
+		mergedBlocks = append(mergedBlocks, blk)
+	}
+	for _, blk := range block2 {
+		mergedBlocks = append(mergedBlocks, blk)
+	}
+	mergedValue, err := ToOrc(mergedBlocks, schema)
+	assert.NoError(t, err)
+
+	orcBuffer := &bytes.Buffer{}
+	writer, _ = eorc.NewWriter(orcBuffer,
+		eorc.SetSchema(orcSchema),
+		eorc.SetCompression(eorc.CompressionZlib{Level: flate.DefaultCompression}))
+	_ = writer.Write("eventName", 1, 1.0)
+	_ = writer.Write("eventName", 2, 2.0)
+	_ = writer.Close()
+
+	if !bytes.Equal(orcBuffer.Bytes(), mergedValue) {
+		t.Fatal("Merged orc value differ")
+	}
+}
+
+func TestMerge_DifferentSchema(t *testing.T) {
+	schema := typeof.Schema{
+		"col0": typeof.String,
+		"col1": typeof.Int64,
+		"col2": typeof.Float64,
+	}
+
+	schema2 := typeof.Schema{
+		"col0": typeof.String,
+		"col1": typeof.Int64,
+		"col2": typeof.Float64,
+		"col3": typeof.String,
+	}
+	orcSchema, err := orc.SchemaFor(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orcSchema2, err := orc.SchemaFor(schema2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orcBuffer1 := &bytes.Buffer{}
+	writer, _ := eorc.NewWriter(orcBuffer1,
+		eorc.SetSchema(orcSchema))
+	_ = writer.Write("eventName", 1, 1.0)
+	_ = writer.Close()
+
+	orcBuffer2 := &bytes.Buffer{}
+	writer, _ = eorc.NewWriter(orcBuffer2,
+		eorc.SetSchema(orcSchema2))
+	_ = writer.Write("eventName", 2, 2.0, "s")
+	_ = writer.Close()
+
+	apply := block.Transform(nil)
+
+	block1, err := block.FromOrcBy(orcBuffer1.Bytes(), "col0", nil, apply)
+	block2, err := block.FromOrcBy(orcBuffer2.Bytes(), "col0", nil, apply)
+
+	mergedBlocks := []block.Block{}
+	for _, blk := range block1 {
+		mergedBlocks = append(mergedBlocks, blk)
+	}
+	for _, blk := range block2 {
+		mergedBlocks = append(mergedBlocks, blk)
+	}
+	mergedValue, err := ToOrc(mergedBlocks, schema2)
+	assert.NoError(t, err)
+
+	orcBuffer := &bytes.Buffer{}
+	writer, _ = eorc.NewWriter(orcBuffer,
+		eorc.SetSchema(orcSchema2),
+		eorc.SetCompression(eorc.CompressionZlib{Level: flate.DefaultCompression}))
+	_ = writer.Write("eventName", 1, 1.0, nil)
+	_ = writer.Write("eventName", 2, 2.0, "s")
+	_ = writer.Close()
+
+	if !bytes.Equal(orcBuffer.Bytes(), mergedValue) {
+		t.Fatal("Merged orc value differ")
+	}
+
+}

--- a/internal/storage/flush/flush_test.go
+++ b/internal/storage/flush/flush_test.go
@@ -5,12 +5,9 @@ package flush
 
 import (
 	"bytes"
-	"compress/flate"
-	"io/ioutil"
 	"testing"
 
 	eorc "github.com/crphang/orc"
-	"github.com/kelindar/binary"
 	"github.com/kelindar/talaria/internal/column"
 	"github.com/kelindar/talaria/internal/encoding/block"
 	"github.com/kelindar/talaria/internal/encoding/orc"
@@ -20,189 +17,6 @@ import (
 	"github.com/kelindar/talaria/internal/storage/writer/noop"
 	"github.com/stretchr/testify/assert"
 )
-
-const testBlockFile = "../../../test/testBlocks"
-
-func TestMerge(t *testing.T) {
-	fileNameFunc := func(row map[string]interface{}) (string, error) {
-		lua, _ := column.NewComputed("fileName", typeof.String, `
-
-		function main(row)
-			current_time = 0
-			fileName = string.format("%s-%d",row["col0"],0)
-			return fileName
-		end`, script.NewLoader(nil))
-
-		output, err := lua.Value(row)
-		return output.(string), err
-	}
-	flusher := New(monitor.NewNoop(), noop.New(), fileNameFunc)
-
-	schema := typeof.Schema{
-		"col0": typeof.String,
-		"col1": typeof.Int64,
-		"col2": typeof.Float64,
-	}
-	orcSchema, err := orc.SchemaFor(schema)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	orcBuffer1 := &bytes.Buffer{}
-	writer, _ := eorc.NewWriter(orcBuffer1,
-		eorc.SetSchema(orcSchema))
-	_ = writer.Write("eventName", 1, 1.0)
-	_ = writer.Close()
-
-	orcBuffer2 := &bytes.Buffer{}
-	writer, _ = eorc.NewWriter(orcBuffer2,
-		eorc.SetSchema(orcSchema))
-	_ = writer.Write("eventName", 2, 2.0)
-	_ = writer.Close()
-
-	apply := block.Transform(nil)
-
-	block1, err := block.FromOrcBy(orcBuffer1.Bytes(), "col0", nil, apply)
-	block2, err := block.FromOrcBy(orcBuffer2.Bytes(), "col0", nil, apply)
-
-	mergedBlocks := []block.Block{}
-	for _, blk := range block1 {
-		mergedBlocks = append(mergedBlocks, blk)
-	}
-	for _, blk := range block2 {
-		mergedBlocks = append(mergedBlocks, blk)
-	}
-	fileName, mergedValue := flusher.Merge(mergedBlocks, schema)
-
-	orcBuffer := &bytes.Buffer{}
-	writer, _ = eorc.NewWriter(orcBuffer,
-		eorc.SetSchema(orcSchema),
-		eorc.SetCompression(eorc.CompressionZlib{Level: flate.DefaultCompression}))
-	_ = writer.Write("eventName", 1, 1.0)
-	_ = writer.Write("eventName", 2, 2.0)
-	_ = writer.Close()
-
-	if !bytes.Equal(orcBuffer.Bytes(), mergedValue) {
-		t.Fatal("Merged orc value differ")
-	}
-
-	if !bytes.Equal([]byte("eventName-0"), fileName) {
-		t.Fatal("File name differ")
-	}
-}
-
-func TestMerge_DifferentSchema(t *testing.T) {
-	fileNameFunc := func(row map[string]interface{}) (string, error) {
-		lua, _ := column.NewComputed("fileName", typeof.String, `
-
-		function main(row)
-			current_time = 0
-			fileName = string.format("%s-%d",row["col0"],0)
-			return fileName
-		end`, script.NewLoader(nil))
-
-		output, err := lua.Value(row)
-		return output.(string), err
-	}
-	flusher := New(monitor.NewNoop(), noop.New(), fileNameFunc)
-
-	schema := typeof.Schema{
-		"col0": typeof.String,
-		"col1": typeof.Int64,
-		"col2": typeof.Float64,
-	}
-
-	schema2 := typeof.Schema{
-		"col0": typeof.String,
-		"col1": typeof.Int64,
-		"col2": typeof.Float64,
-		"col3": typeof.String,
-	}
-	orcSchema, err := orc.SchemaFor(schema)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	orcSchema2, err := orc.SchemaFor(schema2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	orcBuffer1 := &bytes.Buffer{}
-	writer, _ := eorc.NewWriter(orcBuffer1,
-		eorc.SetSchema(orcSchema))
-	_ = writer.Write("eventName", 1, 1.0)
-	_ = writer.Close()
-
-	orcBuffer2 := &bytes.Buffer{}
-	writer, _ = eorc.NewWriter(orcBuffer2,
-		eorc.SetSchema(orcSchema2))
-	_ = writer.Write("eventName", 2, 2.0, "s")
-	_ = writer.Close()
-
-	apply := block.Transform(nil)
-
-	block1, err := block.FromOrcBy(orcBuffer1.Bytes(), "col0", nil, apply)
-	block2, err := block.FromOrcBy(orcBuffer2.Bytes(), "col0", nil, apply)
-
-	mergedBlocks := []block.Block{}
-	for _, blk := range block1 {
-		mergedBlocks = append(mergedBlocks, blk)
-	}
-	for _, blk := range block2 {
-		mergedBlocks = append(mergedBlocks, blk)
-	}
-	fileName, mergedValue := flusher.Merge(mergedBlocks, schema2)
-
-	orcBuffer := &bytes.Buffer{}
-	writer, _ = eorc.NewWriter(orcBuffer,
-		eorc.SetSchema(orcSchema2),
-		eorc.SetCompression(eorc.CompressionZlib{Level: flate.DefaultCompression}))
-	_ = writer.Write("eventName", 1, 1.0, nil)
-	_ = writer.Write("eventName", 2, 2.0, "s")
-	_ = writer.Close()
-
-	if !bytes.Equal(orcBuffer.Bytes(), mergedValue) {
-		t.Fatal("Merged orc value differ")
-	}
-
-	if !bytes.Equal([]byte("eventName-0"), fileName) {
-		t.Fatal("File name differ")
-	}
-}
-
-// BenchmarkFlush runs a benchmark for a Merge function for flushing
-// To run it, go in the directory and do 'go test -benchmem -bench=. -benchtime=1s'
-// BenchmarkFlush/flush-12         	       5	2427187755 ns/op	1872955505 B/op	25340502 allocs/op
-func BenchmarkFlush(b *testing.B) {
-	// create monitor
-	monitor := monitor.NewNoop()
-
-	// Create flusher
-	noopWriter := noop.New()
-
-	fileNameFunc := func(row map[string]interface{}) (string, error) {
-		return "noop", nil
-	}
-
-	flusher := New(monitor, noopWriter, fileNameFunc)
-
-	// Append some files
-
-	blksData, _ := ioutil.ReadFile(testBlockFile)
-	blocks := make([]block.Block, 0)
-	_ = binary.Unmarshal(blksData, &blocks)
-
-	// Run the actual benchmark
-	b.Run("flush", func(b *testing.B) {
-		b.ResetTimer()
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			flusher.Merge(blocks, blocks[0].Schema())
-		}
-	})
-
-}
 
 func TestNameFunc(t *testing.T) {
 	fileNameFunc := func(row map[string]interface{}) (string, error) {
@@ -237,8 +51,8 @@ func TestNameFunc(t *testing.T) {
 		output, err := lua.Value(row)
 		return output.(string), err
 	}
-	flusher := New(monitor.NewNoop(), noop.New(), fileNameFunc)
 
+	flusher, _ := ForCompaction(monitor.NewNoop(), noop.New(), "orc", fileNameFunc)
 	schema := typeof.Schema{
 		"col0": typeof.String,
 		"col1": typeof.Timestamp,
@@ -259,7 +73,7 @@ func TestNameFunc(t *testing.T) {
 	apply := block.Transform(nil)
 
 	blocks, err := block.FromOrcBy(orcBuffer.Bytes(), "col0", nil, apply)
-	fileName, _ := flusher.Merge(blocks, schema)
+	fileName := flusher.generateFileName(blocks[0])
 
 	assert.Equal(t, "year=46970/month=3/day=29/ns=eventName/0-0-0-127.0.0.1.orc", string(fileName))
 

--- a/internal/storage/writer/writer_test.go
+++ b/internal/storage/writer/writer_test.go
@@ -13,13 +13,20 @@ import (
 )
 
 func TestForCompaction(t *testing.T) {
-	cfg := &config.Compaction{}
-	compact := ForCompaction(cfg,
+	cfg := &config.Compaction{
+		Sinks: config.Sinks{
+			File: &config.FileSink{
+				Directory: "./",
+			},
+		},
+	}
+
+	compact, err := ForCompaction(cfg,
 		monitor.New(logging.NewStandard(), statsd.NewNoop(), "x", "x"),
 		disk.New(monitor.NewNoop()),
 		script.NewLoader(nil),
 	)
-
+	assert.NoError(t, err)
 	assert.NotNil(t, compact)
 }
 

--- a/main.go
+++ b/main.go
@@ -114,7 +114,11 @@ func openTable(name string, storageConf config.Storage, tableConf config.Table, 
 	// Create a new storage layer and optional compaction
 	store := storage.Storage(disk.Open(storageConf.Directory, name, monitor, storageConf.Badger))
 	if tableConf.Compact != nil {
-		store = writer.ForCompaction(tableConf.Compact, monitor, store, loader)
+		var err error
+		store, err = writer.ForCompaction(tableConf.Compact, monitor, store, loader)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	// Returns noop streamer if array is empty


### PR DESCRIPTION
This PR has some refactoring that makes the encoder configurable on the global compaction level. This is the groundwork for us to support parquet (and others) as future sink encoders. Going forward, we should also consider making encoder configurable per sink, which would allow us to encode to different formats on different sinks.