### PR TITLE
handle trino client requests supporting presto clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ data
 .idea/
 testdata-*
 .DS_Store
+*.vim
+/*.yaml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ testdata-*
 *.vim
 /*.yaml
 .env
+.envrc
+logs/

--- a/internal/presto/presto.go
+++ b/internal/presto/presto.go
@@ -59,7 +59,7 @@ func Serve(ctx context.Context, port int32, service PrestoThriftService) error {
 		default:
 			if conn, err := ln.Accept(); err == nil {
 				t := thrift.NewTransport(thrift.NewFramedReadWriteCloser(conn, frameSize), thrift.BinaryProtocol)
-				go rpc.ServeCodec(thrift.NewServerCodec(t))
+				go ServeConn(t)
 			}
 		}
 	}

--- a/internal/presto/trino_codec.go
+++ b/internal/presto/trino_codec.go
@@ -87,11 +87,10 @@ func (c *serverCodec) ReadRequestBody(thriftStruct interface{}) error {
 func (c *serverCodec) WriteResponse(response *rpc.Response, thriftStruct interface{}) error {
 
 	var methodName string
-	if val, ok := c.methodName.Load(uint64(response.Seq)); !ok {
+	if val, ok := c.methodName.LoadAndDelete(uint64(response.Seq)); !ok {
 		return fmt.Errorf("rpc: can't find requested seq %d", response.Seq)
 	} else {
 		methodName = val.(string)
-		c.methodName.Delete(uint64(response.Seq))
 	}
 
 	response.ServiceMethod = methodName

--- a/internal/presto/trino_codec.go
+++ b/internal/presto/trino_codec.go
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+
+package presto
+
+import (
+	"errors"
+	"io"
+	"net/rpc"
+	"strings"
+	"sync"
+
+	"github.com/samuel/go-thrift/thrift"
+)
+
+type serverCodec struct {
+	conn       thrift.Transport
+	nameCache  map[string]string // incoming name -> registered name
+	methodName map[uint64]string // sequence ID -> method name
+	mu         sync.Mutex
+}
+
+// ServeConn runs the Thrift RPC server on a single connection. ServeConn blocks,
+// serving the connection until the client hangs up. The caller typically invokes
+// ServeConn in a go statement.
+func ServeConn(conn thrift.Transport) {
+	rpc.ServeCodec(NewServerCodec(conn))
+}
+
+// NewServerCodec returns a new rpc.ServerCodec using Thrift RPC on conn using the specified protocol.
+func NewServerCodec(conn thrift.Transport) rpc.ServerCodec {
+	return &serverCodec{
+		conn:       conn,
+		nameCache:  make(map[string]string, 8),
+		methodName: make(map[uint64]string, 8),
+	}
+}
+
+func (c *serverCodec) ReadRequestHeader(request *rpc.Request) error {
+	name, messageType, seq, err := c.conn.ReadMessageBegin()
+	if err != nil {
+		return err
+	}
+	if messageType != thrift.MessageTypeCall { // Currently don't support one way
+		return errors.New("thrift: expected Call message type")
+	}
+
+	// TODO: should use a limited size cache for the nameCache to avoid a possible
+	//       memory overflow from nefarious or broken clients
+	wireName := name
+	name = strings.Replace(name, "trino", "presto", 1)
+
+	newName := c.nameCache[name]
+	if newName == "" {
+		newName = thrift.CamelCase(name)
+		if !strings.ContainsRune(newName, '.') {
+			newName = "Thrift." + newName
+		}
+		c.nameCache[name] = newName
+	}
+
+	c.mu.Lock()
+	c.methodName[uint64(seq)] = wireName
+	c.mu.Unlock()
+
+	request.ServiceMethod = newName
+	request.Seq = uint64(seq)
+
+	return nil
+}
+
+func (c *serverCodec) ReadRequestBody(thriftStruct interface{}) error {
+	if thriftStruct == nil {
+		if err := thrift.SkipValue(c.conn, thrift.TypeStruct); err != nil {
+			return err
+		}
+	} else {
+		if err := thrift.DecodeStruct(c.conn, thriftStruct); err != nil {
+			return err
+		}
+	}
+	return c.conn.ReadMessageEnd()
+}
+
+func (c *serverCodec) WriteResponse(response *rpc.Response, thriftStruct interface{}) error {
+	c.mu.Lock()
+	methodName := c.methodName[response.Seq]
+	delete(c.methodName, response.Seq)
+	c.mu.Unlock()
+	response.ServiceMethod = methodName
+
+	mtype := byte(thrift.MessageTypeReply)
+	if response.Error != "" {
+		mtype = thrift.MessageTypeException
+		etype := int32(thrift.ExceptionInternalError)
+		if strings.HasPrefix(response.Error, "rpc: can't find") {
+			etype = thrift.ExceptionUnknownMethod
+		}
+		thriftStruct = &thrift.ApplicationException{response.Error, etype}
+	}
+	if err := c.conn.WriteMessageBegin(response.ServiceMethod, mtype, int32(response.Seq)); err != nil {
+		return err
+	}
+	if err := thrift.EncodeStruct(c.conn, thriftStruct); err != nil {
+		return err
+	}
+	if err := c.conn.WriteMessageEnd(); err != nil {
+		return err
+	}
+	return c.conn.Flush()
+}
+
+func (c *serverCodec) Close() error {
+	if cl, ok := c.conn.(io.Closer); ok {
+		return cl.Close()
+	}
+	return nil
+}

--- a/internal/presto/trino_codec_test.go
+++ b/internal/presto/trino_codec_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019-2020 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+package presto
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetWireNameFor(t *testing.T) {
+	wireName := "trino.GetTableMetadata"
+	assert.Equal(t, "presto.GetTableMetadata", getWireNameFor(wireName))
+	wireName = "presto.GetTableMetadata"
+	assert.Equal(t, "presto.GetTableMetadata", getWireNameFor(wireName))
+}

--- a/internal/presto/trino_codec_test.go
+++ b/internal/presto/trino_codec_test.go
@@ -1,5 +1,7 @@
-// Copyright 2019-2020 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
-// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+// Copyright 2012-2015 Samuel Stauffer. All rights reserved.
+// Use of this source code is governed by a 3-clause BSD
+// license that can be found in the LICENSE file at https://github.com/samuel/go-thrift/blob/master/LICENSE.
+
 package presto
 
 import (

--- a/internal/presto/trino_codec_test.go
+++ b/internal/presto/trino_codec_test.go
@@ -3,13 +3,134 @@
 package presto
 
 import (
+	"bytes"
+	"github.com/samuel/go-thrift/thrift"
 	"github.com/stretchr/testify/assert"
+	"net/rpc"
 	"testing"
 )
 
+type ClosingBuffer struct {
+	*bytes.Buffer
+}
+
+func (c *ClosingBuffer) Close() error {
+	return nil
+}
+
+// TestGetWireNameFor replaces the service method,
+//  trino -> presto for 1st occurence
 func TestGetWireNameFor(t *testing.T) {
 	wireName := "trino.GetTableMetadata"
 	assert.Equal(t, "presto.GetTableMetadata", getWireNameFor(wireName))
 	wireName = "presto.GetTableMetadata"
 	assert.Equal(t, "presto.GetTableMetadata", getWireNameFor(wireName))
+}
+
+// TestTrinoCompatibility makes sure the ServerCodec returns the same method name
+// in the response as was in the request.
+// and intercepts the trino service methods to presto service methods
+func TestTrinoCompatibility(t *testing.T) {
+	buf := &ClosingBuffer{&bytes.Buffer{}}
+	clientCodec := thrift.NewClientCodec(thrift.NewTransport(buf, thrift.BinaryProtocol), false)
+	defer clientCodec.Close()
+	serverCodec := NewServerCodec(thrift.NewTransport(buf, thrift.BinaryProtocol))
+	defer serverCodec.Close()
+
+	trinoReq := &rpc.Request{
+		ServiceMethod: "trino.GetSplits",
+		Seq:           143,
+	}
+	empty := &struct{}{}
+	if err := clientCodec.WriteRequest(trinoReq, empty); err != nil {
+		t.Fatal(err)
+	}
+
+	var prestoReq rpc.Request
+	if err := serverCodec.ReadRequestHeader(&prestoReq); err != nil {
+		t.Fatal(err)
+	}
+	if trinoReq.Seq != prestoReq.Seq {
+		t.Fatalf("Expected seq %d, got %d", trinoReq.Seq, prestoReq.Seq)
+	}
+	if prestoReq.ServiceMethod != "Presto.GetSplits" {
+		t.Fatalf("Expected serviceMethod %s, got %s", "Presto.GetSplits", prestoReq.ServiceMethod)
+	}
+	if err := serverCodec.ReadRequestBody(empty); err != nil {
+		t.Fatal(err)
+	}
+	prestoRes := &rpc.Response{
+		ServiceMethod: prestoReq.ServiceMethod,
+		Seq:           prestoReq.Seq,
+	}
+	if err := serverCodec.WriteResponse(prestoRes, empty); err != nil {
+		t.Fatal(err)
+	}
+	var trinoRes rpc.Response
+	if err := clientCodec.ReadResponseHeader(&trinoRes); err != nil {
+		t.Fatal(err)
+	}
+	if trinoRes.Seq != trinoReq.Seq {
+		t.Fatalf("Expected seq %d, got %d", trinoReq.Seq, trinoRes.Seq)
+	}
+	if trinoRes.Error != "" {
+		t.Fatalf("Expected error of '' instead of '%s'", trinoRes.Error)
+	}
+	if trinoRes.ServiceMethod != trinoReq.ServiceMethod {
+		t.Fatalf("Expected ServiceMethod of '%s' instead of '%s'", trinoReq.ServiceMethod, trinoRes.ServiceMethod)
+	}
+}
+
+// TestServerMethodName makes sure the ServerCodec returns the same method name
+// in the response as was in the request.
+//  and presto service method names are not intercepted.
+func TestServerMethodName(t *testing.T) {
+	buf := &ClosingBuffer{&bytes.Buffer{}}
+	clientCodec := thrift.NewClientCodec(thrift.NewTransport(buf, thrift.BinaryProtocol), false)
+	defer clientCodec.Close()
+	serverCodec := NewServerCodec(thrift.NewTransport(buf, thrift.BinaryProtocol))
+	defer serverCodec.Close()
+
+	req := &rpc.Request{
+		ServiceMethod: "presto.GetSplits",
+		Seq:           3,
+	}
+	empty := &struct{}{}
+	if err := clientCodec.WriteRequest(req, empty); err != nil {
+		t.Fatal(err)
+	}
+	var req2 rpc.Request
+	if err := serverCodec.ReadRequestHeader(&req2); err != nil {
+		t.Fatal(err)
+	}
+	if req.Seq != req2.Seq {
+		t.Fatalf("Expected seq %d, got %d", req.Seq, req2.Seq)
+	}
+	t.Logf("Mangled method name: %s", req2.ServiceMethod)
+	if req2.ServiceMethod != "Presto.GetSplits" {
+		t.Fatalf("Expected serviceMethod %s, got %s", "Presto.GetSplits", req2.ServiceMethod)
+	}
+	if err := serverCodec.ReadRequestBody(empty); err != nil {
+		t.Fatal(err)
+	}
+	res := &rpc.Response{
+		ServiceMethod: req2.ServiceMethod,
+		Seq:           req2.Seq,
+	}
+	if err := serverCodec.WriteResponse(res, empty); err != nil {
+		t.Fatal(err)
+	}
+	var res2 rpc.Response
+	if err := clientCodec.ReadResponseHeader(&res2); err != nil {
+		t.Fatal(err)
+	}
+	if res2.Seq != req.Seq {
+		t.Fatalf("Expected seq %d, got %d", req.Seq, res2.Seq)
+	}
+	if res2.Error != "" {
+		t.Fatalf("Expected error of '' instead of '%s'", res2.Error)
+	}
+	if res2.ServiceMethod != req.ServiceMethod {
+		t.Fatalf("Expected ServiceMethod of '%s' instead of '%s'", req.ServiceMethod, res2.ServiceMethod)
+	}
 }


### PR DESCRIPTION
This MR provides forward compatibility with trinodb thrift connector.
Modified the go-thrift library RPC implementations to handle the renaming from trino -> presto, handling the method dispatch map with the renaming.
